### PR TITLE
feat: add PDF encryption support

### DIFF
--- a/ext/qpdf_ruby/document_handle.cpp
+++ b/ext/qpdf_ruby/document_handle.cpp
@@ -1,17 +1,22 @@
+#define POINTERHOLDER_TRANSITION 1
+
 #include "document_handle.hpp"
 
 #include <qpdf/QPDFWriter.hh>
+#include <qpdf/QPDF.hh>
 #include <stdexcept>
 #include <system_error>
 #include <cerrno>
 
 using namespace qpdf_ruby;
 
-std::unique_ptr<DocumentHandle> DocumentHandle::open(const std::string& filename) {
+std::unique_ptr<DocumentHandle> DocumentHandle::open(const std::string& filename, std::string const& pwd) {
   auto qpdf = std::make_shared<QPDF>();
   try {
-    // Use empty password → owner & user pwd same.
-    qpdf->processFile(filename.c_str());
+    qpdf->processFile(filename.c_str(), pwd.empty() ? nullptr : pwd.c_str());
+  } catch (const QPDFExc& qex) {
+    throw std::runtime_error(std::string("qpdf_ruby: failed to open \"") + filename + "\": " + qex.what() +
+                             " (code: " + std::to_string(qex.getErrorCode()) + ")");
   } catch (const std::exception& ex) {
     throw std::runtime_error(std::string("qpdf_ruby: failed to open “") + filename + "”: " + ex.what());
   }
@@ -40,6 +45,7 @@ void DocumentHandle::write(const std::string& out_filename) {
     // honour original file’s extension-level features (linearized? encrypted? …)
     QPDFWriter w(*m_qpdf, out_filename.c_str());
     w.setStaticID(true);  // deterministic IDs – helps tests
+    setup_encryption(w);
     w.write();
   } catch (const std::exception& ex) {
     throw std::runtime_error(std::string("qpdf_ruby: failed to write “") + out_filename + "”: " + ex.what());
@@ -50,6 +56,9 @@ std::string DocumentHandle::write_to_memory() {
   try {
     QPDFWriter w(*m_qpdf, nullptr);
     w.setStaticID(true);
+
+    setup_encryption(w);
+
     w.setOutputMemory();
     w.write();
 
@@ -60,26 +69,62 @@ std::string DocumentHandle::write_to_memory() {
   }
 }
 
-// ------------------------- C bridge impl --------------------------------
+void DocumentHandle::setup_encryption(QPDFWriter& w) const {
+  if (!m_encryption_requested) return;
 
-extern "C" {
-DocumentHandle* qpdf_ruby_open(const char* filename) {
-  try {
-    return DocumentHandle::open(filename).release();
-  } catch (const std::exception&) {
-    errno = EIO;
-    return nullptr;
+  switch (m_encrypt_R) {
+    case 4:
+      w.setR4EncryptionParametersInsecure(m_user_pw.c_str(), m_owner_pw.c_str(), m_encrypt_accessibility,
+                                          m_encrypt_allow_extract, m_encrypt_assemble, m_encrypt_annotate_and_form,
+                                          m_encrypt_form_filling, m_encrypt_allow_modify, m_encrypt_allow_print,
+                                          m_encrypt_encrypt_metadata, m_encrypt_use_aes);
+      break;
+    case 5:
+      w.setR5EncryptionParameters(m_user_pw.c_str(), m_owner_pw.c_str(), m_encrypt_accessibility,
+                                  m_encrypt_allow_extract, m_encrypt_assemble, m_encrypt_annotate_and_form,
+                                  m_encrypt_form_filling, m_encrypt_allow_modify, m_encrypt_allow_print,
+                                  m_encrypt_encrypt_metadata);
+      break;
+    case 6:
+      w.setR6EncryptionParameters(m_user_pw.c_str(), m_owner_pw.c_str(), m_encrypt_accessibility,
+                                  m_encrypt_allow_extract, m_encrypt_assemble, m_encrypt_annotate_and_form,
+                                  m_encrypt_form_filling, m_encrypt_allow_modify, m_encrypt_allow_print,
+                                  m_encrypt_encrypt_metadata);
+      break;
+    default:
+      throw std::runtime_error("Unsupported encryption revision (R): Only 4, 5, 6 are supported.");
   }
 }
 
+void DocumentHandle::set_encryption(const std::string& user_pw, const std::string& owner_pw, int R,
+                                    qpdf_r3_print_e allow_print, bool allow_modify, bool allow_extract,
+                                    bool accessibility, bool assemble, bool annotate_and_form, bool form_filling,
+                                    bool encrypt_metadata, bool use_aes) {
+  m_user_pw = user_pw;
+  m_owner_pw = owner_pw;
+  m_encrypt_R = R;
+  m_encrypt_allow_print = allow_print;
+  m_encrypt_allow_modify = allow_modify;
+  m_encrypt_allow_extract = allow_extract;
+  m_encrypt_accessibility = accessibility;
+  m_encrypt_assemble = assemble;
+  m_encrypt_annotate_and_form = annotate_and_form;
+  m_encrypt_form_filling = form_filling;
+  m_encrypt_encrypt_metadata = encrypt_metadata;
+  m_encrypt_use_aes = use_aes;
+  m_encryption_requested = true;
+}
+
+// ------------------------- C bridge impl --------------------------------
+
+extern "C" {
+DocumentHandle* qpdf_ruby_open(const char* filename, char const* pwd) {
+  return DocumentHandle::open(filename, pwd ? pwd : "").release();
+}
+
 DocumentHandle* qpdf_ruby_open_memory(char const* desc, unsigned char const* buf, size_t len, char const* pwd) {
-  try {
-    std::vector<unsigned char> copy(buf, buf + len);  // simple ownership
-    return DocumentHandle::open_memory(desc, std::move(copy), pwd ? pwd : "").release();
-  } catch (...) {
-    errno = EIO;
-    return nullptr;
-  }
+  std::vector<unsigned char> copy(buf, buf + len);  // simple ownership
+  return DocumentHandle::open_memory(desc, std::move(copy), pwd ? pwd : "").release();
 }
 
 int qpdf_ruby_write(DocumentHandle* handle, const char* out_filename) {
@@ -87,13 +132,20 @@ int qpdf_ruby_write(DocumentHandle* handle, const char* out_filename) {
     errno = EBADF;
     return -1;
   }
-  try {
-    handle->write(out_filename);
-    return 0;
-  } catch (const std::exception&) {
-    errno = EIO;
-    return -1;
-  }
+
+  handle->write(out_filename);
+  return 0;
+}
+
+void qpdf_ruby_set_encryption(DocumentHandle* handle, const char* user_pw, const char* owner_pw, int R,
+                              qpdf_r3_print_e allow_print, int allow_modify, int allow_extract, int accessibility,
+                              int assemble, int annotate_and_form, int form_filling, int encrypt_metadata,
+                              int use_aes) {
+  if (!handle) return;
+
+  handle->set_encryption(std::string(user_pw ? user_pw : ""), std::string(owner_pw ? owner_pw : ""), R, allow_print,
+                         allow_modify != 0, allow_extract != 0, accessibility != 0, assemble != 0,
+                         annotate_and_form != 0, form_filling != 0, encrypt_metadata != 0, use_aes != 0);
 }
 
 void qpdf_ruby_close(DocumentHandle* handle) {

--- a/ext/qpdf_ruby/document_handle.hpp
+++ b/ext/qpdf_ruby/document_handle.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#define POINTERHOLDER_TRANSITION 1
+
 #include <memory>
 #include <string>
 #include <qpdf/QPDF.hh>
+#include <qpdf/QPDFWriter.hh>
 
 namespace qpdf_ruby {
 
@@ -16,7 +19,7 @@ namespace qpdf_ruby {
 class DocumentHandle final {
  public:
   // ---- factory ----------------------------------------------------------
-  static std::unique_ptr<DocumentHandle> open(const std::string& filename);
+  static std::unique_ptr<DocumentHandle> open(const std::string& filename, std::string const& pwd);
   static std::unique_ptr<DocumentHandle> open_memory(std::string const& description, std::vector<unsigned char> data,
                                                      std::string const& password = "");
 
@@ -25,6 +28,12 @@ class DocumentHandle final {
   void write(const std::string& out_filename);
 
   std::string write_to_memory();
+
+  void set_encryption(const std::string& user_pw, const std::string& owner_pw, int R, qpdf_r3_print_e allow_print,
+                      bool allow_modify, bool allow_extract, bool accessibility = true, bool assemble = true,
+                      bool annotate_and_form = true, bool form_filling = true, bool encrypt_metadata = true,
+                      bool use_aes = true);
+  void setup_encryption(QPDFWriter& w) const;
 
   /** Direct access for C++ helpers that need the raw QPDF. */
   QPDF& qpdf() { return *m_qpdf; }
@@ -42,11 +51,26 @@ class DocumentHandle final {
 
   std::shared_ptr<QPDF> m_qpdf;
   std::vector<unsigned char> m_owned_buf;
+
+  // --- New encryption settings ---
+  bool m_encryption_requested = false;
+  std::string m_user_pw;
+  std::string m_owner_pw;
+  int m_encrypt_R = 4;
+  qpdf_r3_print_e m_encrypt_allow_print{qpdf_r3p_full};
+  bool m_encrypt_allow_modify = true;
+  bool m_encrypt_allow_extract = true;
+  bool m_encrypt_accessibility = true;
+  bool m_encrypt_assemble = true;
+  bool m_encrypt_annotate_and_form = true;
+  bool m_encrypt_form_filling = true;
+  bool m_encrypt_encrypt_metadata = true;
+  bool m_encrypt_use_aes = true;
 };
 
 extern "C" {
 /** Returns a freshly allocated handle or nullptr on error (see errno). */
-DocumentHandle* qpdf_ruby_open(const char* filename);
+DocumentHandle* qpdf_ruby_open(const char* filename, char const* pwd);
 
 DocumentHandle* qpdf_ruby_open_memory(char const* desc, unsigned char const* buf, size_t len, char const* pwd);
 
@@ -56,5 +80,11 @@ int qpdf_ruby_write(DocumentHandle* handle, const char* out_filename);
 /** Deletes the handle (idempotent). */
 void qpdf_ruby_close(DocumentHandle* handle);
 }
+
+void qpdf_ruby_set_encryption(struct DocumentHandle* handle, const char* user_pw, const char* owner_pw, int R,
+                              qpdf_r3_print_e allow_print,
+                              int allow_modify,  // bool as int (0/1)
+                              int allow_extract, int accessibility, int assemble, int annotate_and_form,
+                              int form_filling, int encrypt_metadata, int use_aes);
 
 }  // namespace qpdf_ruby

--- a/ext/qpdf_ruby/pdf_image_mapper.hpp
+++ b/ext/qpdf_ruby/pdf_image_mapper.hpp
@@ -1,6 +1,8 @@
 // x_object_finder.hpp
 #pragma once
 
+#define POINTERHOLDER_TRANSITION 1
+
 #include <qpdf/QPDF.hh>
 #include <qpdf/QPDFPageDocumentHelper.hh>
 #include <qpdf/QPDFPageObjectHelper.hh>

--- a/ext/qpdf_ruby/pdf_struct_walker.hpp
+++ b/ext/qpdf_ruby/pdf_struct_walker.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#define POINTERHOLDER_TRANSITION 1
+
 #include <qpdf/QPDF.hh>
 #include <qpdf/QPDFWriter.hh>
 #include <qpdf/QPDFPageObjectHelper.hh>

--- a/ext/qpdf_ruby/qpdf_ruby.hpp
+++ b/ext/qpdf_ruby/qpdf_ruby.hpp
@@ -6,5 +6,6 @@
 VALUE rb_qpdf_mark_paths_as_artifacts(VALUE self);
 VALUE rb_qpdf_ensure_bboxs(VALUE self);
 VALUE rb_qpdf_get_structure_string(VALUE self);
+VALUE rb_qpdf_doc_set_encryption(int argc, VALUE* argv, VALUE self);
 
 #endif /* QPDF_RUBY_H */

--- a/ext/qpdf_ruby/struct_node.hpp
+++ b/ext/qpdf_ruby/struct_node.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#define POINTERHOLDER_TRANSITION 1
+
 #include <qpdf/QPDF.hh>
 #include <qpdf/QPDFWriter.hh>
 #include <qpdf/QPDFPageObjectHelper.hh>

--- a/lib/qpdf_ruby.rb
+++ b/lib/qpdf_ruby.rb
@@ -4,6 +4,10 @@ require_relative "qpdf_ruby/version"
 require_relative "qpdf_ruby/qpdf_ruby"
 
 module QpdfRuby
+  ENCRYPTION_REVISION_AES_128  = 4  # Acrobat 6.x, 128-bit AES
+  ENCRYPTION_REVISION_AES_256  = 5  # Acrobat 9.x, 256-bit AES
+  ENCRYPTION_REVISION_AES_256U = 6  # Acrobat X, 256-bit AES (PDF 2.0+ update)
+
   class Error < StandardError; end
   # Your code goes here...
 end

--- a/spec/qpdf_ruby_spec.rb
+++ b/spec/qpdf_ruby_spec.rb
@@ -52,4 +52,39 @@ RSpec.describe QpdfRuby do
 
     expect(actual_xml.to_s).to eq(expected_xml.to_s)
   end
+
+  it "sets a password on a PDF" do
+    doc = QpdfRuby::Document.new(fixture_file("example_accessibility.pdf"))
+
+    # only needed to get the expected structure
+    doc.mark_paths_as_artifacts
+    doc.ensure_bbox
+
+    doc.encrypt(
+      user_pw: "userpass",
+      owner_pw: "ownerpass",
+      encryption_revision: QpdfRuby::ENCRYPTION_REVISION_AES_256U,
+      allow_print: QpdfRuby::PRINT_LOW,
+      allow_modify: true,
+      allow_extract: false,
+      accessibility: true,
+      assemble: false,
+      annotate_and_form: false,
+      form_filling: false,
+      encrypt_metadata: true,
+      use_aes: true
+    )
+
+    doc.write tmp_file
+
+    passsword = %w[userpass ownerpass].sample
+
+    protected_doc = QpdfRuby::Document.new(tmp_file, passsword)
+    actual_structure = protected_doc.show_structure
+
+    actual_xml = Nokogiri::XML(actual_structure, &:noblanks)
+    expected_xml = Nokogiri::XML(expected_structure, &:noblanks)
+
+    expect(actual_xml.to_s).to eq(expected_xml.to_s)
+  end
 end


### PR DESCRIPTION
Implement methods to set and apply encryption settings for PDF documents. This includes user and owner password management, as well as configurable permissions for printing and modifying the document.